### PR TITLE
Implement KPI Dashboard with API backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jttrani

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-# Ignore node modules and build artifacts
 node_modules/
-dist/
 .env
+.DS_Store
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,28 +1,47 @@
-# Crew Management System Login Demo
+# Crew Management System
 
-This repository contains a simple responsive login page for a Crew Management System.
+This repository provides a simple login page and a KPI Dashboard module used for crew management. The dashboard is built with **React** and **Chart.js**, while a small **Node.js** API serves data from MySQL.
 
 ## Features
 
-- Username/email and password fields
-- Error message display for invalid input
-- Password visibility toggle
-- Maritime-themed background with 50% opacity
-- Animated wave effect at the bottom of the page
-- Responsive design optimized for desktop and mobile
+- Responsive login page (demo)
+- KPI Dashboard
+  - **Joining Ratio** – total crew joined vs. expected onboard per month
+  - **Retention Rate** – percentage of crew with at least two contracts or over one year tenure
+  - **Incident Trend** – monthly count of P&I or safety incidents
+- Utility-first styling with Tailwind CSS
 
-## Usage
+## Setup
 
-1. Clone the repository.
-2. Open `index.html` in your browser or serve the directory with a local web server.
+### Backend API
+1. Install Node.js and MySQL.
+2. Create a `.env` file in `server/` with database credentials:
+   ```ini
+   DB_HOST=localhost
+   DB_USER=root
+   DB_PASSWORD=secret
+   DB_NAME=crewdb
+   ```
+3. Install dependencies and start the server:
+   ```bash
+   cd server
+   npm install
+   npm start
+   ```
+   The API will run on `http://localhost:3001`.
 
-This page is for demonstration purposes only. It performs a very basic front-end credential check and **should not** be used in production without a proper backend and secure authentication mechanism.
+### Frontend
+Open `dashboard/index.html` in your browser. It fetches data from the API endpoints:
+- `/api/joining-ratio?month=YYYY-MM`
+- `/api/retention-rate`
+- `/api/incidents?start=YYYY-MM&end=YYYY-MM`
 
-### Can I hide the page source?
-
-No. Modern browsers allow users to view HTML, CSS, and JavaScript that are served to them. You can try techniques such as disabling the context menu or key shortcuts and minifying/obfuscating code, but a determined user can still access the source. Security should rely on robust server-side code rather than hiding client-side files.
-
-## Contributing
-
+## Development
 Pull requests are welcome. Please open an issue first to discuss changes.
 
+## Testing
+Run the following in the `server` directory:
+```bash
+npm test
+```
+(Currently no automated tests are defined.)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="bg-gray-100 min-h-screen p-4">
+  <div id="root"></div>
+  <script type="text/babel" src="./src/App.js"></script>
+</body>
+</html>

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -1,0 +1,73 @@
+const { useState, useEffect } = React;
+
+function LineChart({ labels, data, label }) {
+  const canvasRef = React.useRef(null);
+  useEffect(() => {
+    const ctx = canvasRef.current.getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label,
+          data,
+          borderColor: 'rgba(99,102,241)',
+          backgroundColor: 'rgba(99,102,241,0.3)',
+        }],
+      },
+      options: { responsive: true }
+    });
+  }, [labels, data]);
+  return <canvas ref={canvasRef}></canvas>;
+}
+
+function KPICard({ title, children }) {
+  return (
+    <div className="bg-white shadow rounded p-4 flex flex-col">
+      <h2 className="text-lg font-semibold mb-2">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function App() {
+  const [joining, setJoining] = useState({ joined: 0, expected: 0 });
+  const [retention, setRetention] = useState(0);
+  const [incidentData, setIncidentData] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/joining-ratio?month=2024-01')
+      .then(res => res.json())
+      .then(setJoining);
+
+    fetch('/api/retention-rate')
+      .then(res => res.json())
+      .then(data => setRetention(data.rate));
+
+    fetch('/api/incidents?start=2023-01&end=2024-01')
+      .then(res => res.json())
+      .then(setIncidentData);
+  }, []);
+
+  return (
+    <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
+      <KPICard title="Joining Ratio">
+        <p className="text-2xl">{joining.joined} / {joining.expected}</p>
+      </KPICard>
+      <KPICard title="Retention Rate">
+        <p className="text-2xl">{(retention*100).toFixed(1)}%</p>
+      </KPICard>
+      <div className="md:col-span-2">
+        <KPICard title="Incident Trend">
+          <LineChart
+            labels={incidentData.map(d => d.month)}
+            data={incidentData.map(d => d.count)}
+            label="Incidents"
+          />
+        </KPICard>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,13 @@
+import mysql from 'mysql2/promise';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'crewdb',
+  waitForConnections: true,
+  connectionLimit: 10,
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "crew-management-api",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mysql2": "^3.5.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/server/routes/kpi.js
+++ b/server/routes/kpi.js
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { pool } from '../db.js';
+
+const router = Router();
+
+router.get('/joining-ratio', async (req, res) => {
+  const { month } = req.query; // format YYYY-MM
+  const [expected] = await pool.query(
+    `SELECT COUNT(*) as total FROM crew_schedule WHERE DATE_FORMAT(join_date,'%Y-%m')=?`,
+    [month]
+  );
+  const [joined] = await pool.query(
+    `SELECT COUNT(*) as total FROM crew WHERE DATE_FORMAT(joined_on,'%Y-%m')=?`,
+    [month]
+  );
+  res.json({ expected: expected[0].total, joined: joined[0].total });
+});
+
+router.get('/retention-rate', async (_req, res) => {
+  const [rows] = await pool.query(
+    `SELECT COUNT(*) as retained FROM crew WHERE contracts_completed>=2 OR TIMESTAMPDIFF(MONTH, joined_on, NOW())>=12`
+  );
+  const [total] = await pool.query(`SELECT COUNT(*) as total FROM crew`);
+  const rate = total[0].total ? rows[0].retained / total[0].total : 0;
+  res.json({ rate });
+});
+
+router.get('/incidents', async (req, res) => {
+  const { start, end } = req.query; // YYYY-MM
+  const [rows] = await pool.query(
+    `SELECT DATE_FORMAT(date,'%Y-%m') as month, COUNT(*) as count FROM incidents
+     WHERE type IN ('P&I','safety') AND date BETWEEN ? AND ?
+     GROUP BY month ORDER BY month`
+  , [start + '-01', end + '-31']);
+  res.json(rows);
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import cors from 'cors';
+import kpiRoutes from './routes/kpi.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api', kpiRoutes);
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`API server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add git ignore and CODEOWNERS
- implement Node.js API with KPI endpoints
- create React-based dashboard using Chart.js and Tailwind CSS
- document setup instructions

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68527326fdd08325b6e0b3dffcf0db49