### PR TITLE
Add contract generator prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 .env
+contract-generator/backend/node_modules/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ No. Modern browsers allow users to view HTML, CSS, and JavaScript that are serve
 
 Pull requests are welcome. Please open an issue first to discuss changes.
 
+
+## Contract Generator (prototype)
+
+The `contract-generator` directory contains a proof-of-concept React/Node.js module for generating crew contracts. It demonstrates:
+
+- Dropdowns populated from a MySQL database.
+- Auto-fetching salary scales based on vessel, rank, and year.
+- PDF generation using jsPDF.
+- Simple REST backend written in Express.
+
+See `contract-generator/README.md` for setup instructions.

--- a/contract-generator/README.md
+++ b/contract-generator/README.md
@@ -1,0 +1,19 @@
+# Contract Generator Module
+
+This module provides a simple proof-of-concept for generating crew employment contracts.
+It uses a React-based front end and a Node.js (Express) backend with MySQL.
+
+## Folder structure
+
+- `frontend/` – Single page application using React and Bootstrap 5.
+- `backend/` – Express server exposing REST endpoints for vessel, rank and contract management.
+
+## Setup
+
+1. Install Node.js and MySQL.
+2. In `backend/` run `npm install` to install dependencies.
+3. Configure database credentials via environment variables as shown in `backend/server.js`.
+4. Start the API with `node server.js`.
+5. Serve the `frontend/index.html` file using any web server or open it directly.
+
+This is a minimal demonstration and does not include authentication or advanced error handling.

--- a/contract-generator/backend/package.json
+++ b/contract-generator/backend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "contract-generator-backend",
+  "version": "0.1.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mysql2": "^3.1.0",
+    "cors": "^2.8.5"
+  }
+}

--- a/contract-generator/backend/server.js
+++ b/contract-generator/backend/server.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const mysql = require('mysql2/promise');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Connection pool using environment variables
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'crew_management',
+});
+
+// Fetch vessels
+app.get('/api/vessels', async (_, res) => {
+  try {
+    const [rows] = await pool.query('SELECT id, name FROM vessels');
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Fetch ranks
+app.get('/api/ranks', async (_, res) => {
+  try {
+    const [rows] = await pool.query('SELECT id, name FROM ranks');
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Fetch salary scale for rank/vessel/year
+app.get('/api/salary', async (req, res) => {
+  const { rankId, vesselId, year } = req.query;
+  try {
+    const [rows] = await pool.query(
+      'SELECT amount FROM salary_scales WHERE rank_id=? AND vessel_id=? AND year=?',
+      [rankId, vesselId, year]
+    );
+    res.json(rows[0] || { amount: 0 });
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Create contract entry and return ID
+app.post('/api/contracts', async (req, res) => {
+  const { vesselId, rankId, salary, duration, content } = req.body;
+  try {
+    const [result] = await pool.query(
+      'INSERT INTO contracts (vessel_id, rank_id, salary, duration, content) VALUES (?, ?, ?, ?, ?)',
+      [vesselId, rankId, salary, duration, content]
+    );
+    res.json({ id: result.insertId });
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/contract-generator/frontend/app.js
+++ b/contract-generator/frontend/app.js
@@ -1,0 +1,95 @@
+const { useState, useEffect } = React;
+
+function ContractGenerator() {
+  const [vessels, setVessels] = useState([]);
+  const [ranks, setRanks] = useState([]);
+  const [form, setForm] = useState({
+    vesselId: '',
+    rankId: '',
+    year: new Date().getFullYear(),
+    salary: '',
+    duration: '',
+  });
+
+  useEffect(() => {
+    fetch('/api/vessels').then(res => res.json()).then(setVessels);
+    fetch('/api/ranks').then(res => res.json()).then(setRanks);
+  }, []);
+
+  useEffect(() => {
+    if (form.vesselId && form.rankId) {
+      fetch(`/api/salary?rankId=${form.rankId}&vesselId=${form.vesselId}&year=${form.year}`)
+        .then(res => res.json())
+        .then(data => setForm(f => ({ ...f, salary: data.amount })));
+    }
+  }, [form.vesselId, form.rankId, form.year]);
+
+  const update = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const generatePdf = () => {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.text(`Vessel: ${form.vesselId}`, 10, 10);
+    doc.text(`Rank: ${form.rankId}`, 10, 20);
+    doc.text(`Salary: ${form.salary}`, 10, 30);
+    doc.text(`Duration: ${form.duration}`, 10, 40);
+    doc.save('contract.pdf');
+  };
+
+  const submit = async () => {
+    const res = await fetch('/api/contracts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        vesselId: form.vesselId,
+        rankId: form.rankId,
+        salary: form.salary,
+        duration: form.duration,
+        content: JSON.stringify(form),
+      }),
+    });
+    if (res.ok) generatePdf();
+  };
+
+  return (
+    <div className="card">
+      <div className="card-body">
+        <h3 className="card-title mb-3">Contract Generator</h3>
+        <div className="row mb-2">
+          <div className="col">
+            <label className="form-label">Vessel</label>
+            <select name="vesselId" className="form-select" value={form.vesselId} onChange={update}>
+              <option value="">Select vessel</option>
+              {vessels.map(v => <option key={v.id} value={v.id}>{v.name}</option>)}
+            </select>
+          </div>
+          <div className="col">
+            <label className="form-label">Rank</label>
+            <select name="rankId" className="form-select" value={form.rankId} onChange={update}>
+              <option value="">Select rank</option>
+              {ranks.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+            </select>
+          </div>
+        </div>
+        <div className="row mb-2">
+          <div className="col">
+            <label className="form-label">Year</label>
+            <input type="number" name="year" className="form-control" value={form.year} onChange={update} />
+          </div>
+          <div className="col">
+            <label className="form-label">Duration (months)</label>
+            <input type="number" name="duration" className="form-control" value={form.duration} onChange={update} />
+          </div>
+        </div>
+        <div className="mb-2">
+          <label className="form-label">Salary</label>
+          <input type="number" name="salary" className="form-control" value={form.salary} onChange={update} />
+          <div className="form-text">Auto-populated from scale, editable if necessary.</div>
+        </div>
+        <button className="btn btn-primary" onClick={submit}>Generate Contract</button>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<ContractGenerator />);

--- a/contract-generator/frontend/index.html
+++ b/contract-generator/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contract Generator</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-4" id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add contract-generator module with React frontend and Node.js backend
- backend exposes REST endpoints with MySQL
- frontend demonstrates dropdowns, salary lookup, PDF generation
- document how to run the prototype

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68527353ad78832585f5b8599eaa0a4b