### PR TITLE
Add Salary Scale Manager module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository provides a simple login page and a KPI Dashboard module used for
   - **Retention Rate** – percentage of crew with at least two contracts or over one year tenure
   - **Incident Trend** – monthly count of P&I or safety incidents
 - Utility-first styling with Tailwind CSS
+- **Salary Scale Manager** – maintain yearly salary scale history by crew rank
 
 ## Setup
 
@@ -35,6 +36,16 @@ Open `dashboard/index.html` in your browser. It fetches data from the API endpoi
 - `/api/joining-ratio?month=YYYY-MM`
 - `/api/retention-rate`
 - `/api/incidents?start=YYYY-MM&end=YYYY-MM`
+
+### Salary Scale Manager
+1. Start the salary scale API:
+   ```bash
+   cd salary-scale-manager/backend
+   npm install
+   npm start
+   ```
+   The API will run on `http://localhost:3002`.
+2. Open `salary-scale-manager/frontend/index.html` in your browser to manage yearly salary scales by rank.
 
 ## Development
 Pull requests are welcome. Please open an issue first to discuss changes.

--- a/salary-scale-manager/README.md
+++ b/salary-scale-manager/README.md
@@ -1,0 +1,18 @@
+# Salary Scale Manager
+
+This module provides a simple interface for maintaining yearly salary scale data by crew rank. It includes a React based front end and a small Node.js backend that exposes REST endpoints. Data is persisted in MySQL.
+
+## Folder structure
+
+- `frontend/` – React components powered by vanilla ES modules and Bootstrap 5.
+- `backend/` – Express API that performs CRUD operations on the `salary_scales` table.
+
+## Setup
+
+1. Ensure Node.js and MySQL are installed. When running locally via XAMPP, MySQL should already be available.
+2. In `backend/` run `npm install` to install dependencies.
+3. Create a `.env` file in `backend/` with database credentials (see `server.js`).
+4. Start the API with `node server.js`.
+5. Open `frontend/index.html` in a browser to access the manager.
+
+This module is independent from the dashboard and contract generator, but uses the same `salary_scales` table.

--- a/salary-scale-manager/backend/package.json
+++ b/salary-scale-manager/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "salary-scale-manager-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "mysql2": "^3.5.2",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/salary-scale-manager/backend/server.js
+++ b/salary-scale-manager/backend/server.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import mysql from 'mysql2/promise';
+
+dotenv.config();
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'crewdb',
+});
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// List salary scale history for a rank
+app.get('/api/salary-scales/:rankId', async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      'SELECT id, year, amount FROM salary_scales WHERE rank_id = ? ORDER BY year DESC',
+      [req.params.rankId]
+    );
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+// Add a new salary scale record
+app.post('/api/salary-scales', async (req, res) => {
+  const { rankId, year, amount } = req.body;
+  try {
+    const [result] = await pool.query(
+      'INSERT INTO salary_scales (rank_id, year, amount) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE amount = VALUES(amount)',
+      [rankId, year, amount]
+    );
+    res.json({ id: result.insertId || result.affectedRows });
+  } catch (err) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+const PORT = process.env.PORT || 3002;
+app.listen(PORT, () => {
+  console.log(`Salary Scale API running on port ${PORT}`);
+});

--- a/salary-scale-manager/frontend/app.js
+++ b/salary-scale-manager/frontend/app.js
@@ -1,0 +1,75 @@
+const { useState, useEffect } = React;
+
+function SalaryScaleManager() {
+  const [ranks, setRanks] = useState([]);
+  const [selectedRank, setSelectedRank] = useState('');
+  const [scales, setScales] = useState([]);
+  const [form, setForm] = useState({ year: new Date().getFullYear(), amount: '' });
+
+  useEffect(() => {
+    fetch('/api/ranks').then(res => res.json()).then(setRanks);
+  }, []);
+
+  useEffect(() => {
+    if (selectedRank) {
+      fetch(`/api/salary-scales/${selectedRank}`).then(res => res.json()).then(setScales);
+    }
+  }, [selectedRank]);
+
+  const update = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const submit = async () => {
+    await fetch('/api/salary-scales', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rankId: selectedRank, ...form })
+    });
+    setForm({ year: new Date().getFullYear(), amount: '' });
+    const res = await fetch(`/api/salary-scales/${selectedRank}`);
+    setScales(await res.json());
+  };
+
+  return (
+    <div className="card">
+      <div className="card-body">
+        <h3 className="card-title mb-3">Salary Scale Manager</h3>
+        <div className="mb-3">
+          <label className="form-label">Rank</label>
+          <select className="form-select" value={selectedRank} onChange={e => setSelectedRank(e.target.value)}>
+            <option value="">Select rank</option>
+            {ranks.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+          </select>
+        </div>
+
+        {selectedRank && (
+          <>
+            <table className="table table-sm table-bordered">
+              <thead>
+                <tr><th>Year</th><th>Amount</th></tr>
+              </thead>
+              <tbody>
+                {scales.map(s => (
+                  <tr key={s.id}><td>{s.year}</td><td>{s.amount}</td></tr>
+                ))}
+              </tbody>
+            </table>
+
+            <div className="row g-2 mt-3">
+              <div className="col">
+                <input type="number" name="year" className="form-control" value={form.year} onChange={update} />
+              </div>
+              <div className="col">
+                <input type="number" name="amount" className="form-control" value={form.amount} onChange={update} />
+              </div>
+              <div className="col-auto">
+                <button className="btn btn-primary" onClick={submit}>Save</button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<SalaryScaleManager />);

--- a/salary-scale-manager/frontend/index.html
+++ b/salary-scale-manager/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Salary Scale Manager</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-4" id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support tracking salary scale history by crew rank
- document new module and usage steps
- ignore node_modules and environment files

## Testing
- `npm test` in `server/` *(passes: No tests specified)*
- `npm test` in `contract-generator/backend` *(fails: missing script)*
- `npm test` in `salary-scale-manager/backend` *(passes: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68527422495c8325b4930dbeb2856e6d